### PR TITLE
Fix problems with common.sh on Lumi

### DIFF
--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -77,7 +77,7 @@ fi
 fi
 
 echo "
-if [[ \"\$( cat /proc/self/mountinfo)\" == *\"singularity/mnt/session\"* ]];then
+if [[ grep singularity/mnt/session /proc/self/mountinfo ]];then
     export _CW_IN_CONTAINER=Yes
 else
     unset _CW_IN_CONTAINER


### PR DESCRIPTION
On Lumi, the $(cat fails with:
/appl/local/quantum/helmi/soft/qiskit-iqm-2.0/bin/../common.sh: line 12:
  /usr/bin/cat: Argument list too long

Switch to use grep and directly use the return value.


Please mark this with the hacktoberfest-approved  label if approved.
