### PR TITLE
Adds sh shell option

### DIFF
--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -119,8 +119,15 @@ _GENERATED_WRAPPERS=""
 mkdir _deploy/_bin
 
 print_info "Creating wrappers" 1
+# Just in case the container does not contain bash
+if [[ -z $($_CONTAINER_EXEC bash --version 2>/dev/null) ]] && [[ "$CW_ISOLATE" == "yes" ]] ;then
+    print_info "Using sh inside the container as bash was not found" 1
+   _default_cws="sh -c \""
+else
+   _default_cws="bash -c \""
+fi
 for wrapper_path in "${CW_WRAPPER_PATHS[@]}";do
-    _cws="bash -c \""
+    _cws="$_default_cws"
     _cwe="\$( test \$# -eq 0 || printf \" %q\" \"\$@\" )\""
     print_info "Generating wrappers for $wrapper_path" 2
     if $_CONTAINER_EXEC test -f $wrapper_path ; then


### PR DESCRIPTION
Some very light containers are missing the bash shell which breaks our startup scripts inside the container.

We add a check to test if bash is missing and switch to sh only if the isolate options is true,
as otherwise a bash shell will be available from outside