### PR TITLE
Fix bug in `generate_wrappers.sh`

### DIFF
--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -77,7 +77,7 @@ fi
 fi
 
 echo "
-if [[ grep singularity/mnt/session /proc/self/mountinfo ]];then
+if grep singularity/mnt/session /proc/self/mountinfo ;then
     export _CW_IN_CONTAINER=Yes
 else
     unset _CW_IN_CONTAINER

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -77,7 +77,7 @@ fi
 fi
 
 echo "
-if grep singularity/mnt/session /proc/self/mountinfo ;then
+if grep -q 'singularity/mnt/session|apptainer/mnt/session' /proc/self/mountinfo ;then
     export _CW_IN_CONTAINER=Yes
 else
     unset _CW_IN_CONTAINER


### PR DESCRIPTION
This bug was spotted running `tests/tests.sh` on LUMI. When creating a conda container `common.sh` cannot be sourced as there is a bash error in line 12 of `generate_wrappers.sh`: `line 12: conditional binary operator expected`. 

## Reproduce 

`conda_base.yml` >>
```
channels:
  - conda-forge
dependencies:
  - numpy
```

`req.txt` >>
```
pyyaml
```

mkdir -p TEST_DIR/CONDA_INSTALL_DIR

```bash
conda-containerize new TEST_DIR/conda_base.yml -r TEST_DIR/req.txt --prefix TEST_DIR/CONDA_INSTALL_DIR
```

Opening a simple python shell e.g `TEST_DIR/CONDA_INSTALL_DIR/bin/python` :

```
hpc-container-wrapper/tests/TEST_DIR/CONDA_INSTALL_DIR/bin/../common.sh: line 12: conditional binary operator expected
hpc-container-wrapper/tests/TEST_DIR/CONDA_INSTALL_DIR/bin/../common.sh: line 12: syntax error near `singularity/mnt/session'
hpc-container-wrapper/tests/TEST_DIR/CONDA_INSTALL_DIR/bin/../common.sh: line 12: `if [[ grep singularity/mnt/session /proc/self/mountinfo ]];then'
```

It seems that sourcing `common.sh` is the problem

```
-bash: TEST_DIR/CONDA_INSTALL_DIR/common.sh: line 12: conditional binary operator expected
-bash: TEST_DIR/CONDA_INSTALL_DIR/common.sh: line 12: syntax error near `singularity/mnt/session'
-bash: TEST_DIR/CONDA_INSTALL_DIR/common.sh: line 12: `if [[ grep singularity/mnt/session /proc/self/mountinfo ]];then'
```

## Suggested solution

Quick tests show that removing the `[[...]]` solves the problem. If you can think of a more elegant solution please contrib :). 

- Not tested on Puhti
- Not tested on Mahti
- Not tested with pip-containerize or wrapped installation, however off the top of my head I can't see any problem. 

The above shouldn't be a problem unless the bash versions are vastly different. 



