### PR TITLE
Update generate_wrappers.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ Don't delete build files when failing.
 `CW_LOG_LEVEL`
 How verbosely to report program actions
 
+`CW_FORCE_CONDA_ACTIVATE`
+Force conda to be activated even if called through a virtual environment. 
+
 - 0 only error
 - 1 only warnings
 - 2 general (default)

--- a/README.md
+++ b/README.md
@@ -224,15 +224,17 @@ These can be set before starting the tool
 `CW_GLOBAL_YAML`
 path to config to use
 
+`CW_ENABLE_CONDARC`
+enable user condarc during installation
 
 `CW_DEBUG_KEEP_FILES`
 Don't delete build files when failing. 
 
-`CW_LOG_LEVEL`
-How verbosely to report program actions
-
 `CW_FORCE_CONDA_ACTIVATE`
 Force conda to be activated even if called through a virtual environment. 
+
+`CW_LOG_LEVEL`
+How verbosely to report program actions
 
 - 0 only error
 - 1 only warnings
@@ -250,7 +252,8 @@ ordering within both matter! -> nested bind mounts possible.
 Note that while loop devices can be mounted on bind mounts,
 any extra bind mounts will be applied after extra loop device (image mounts) 
 so to mask dirs on disk with an image mount, the path can not be bind mounted.
-(exception is the default $HOME mount, which is applied before loop device mounts)
+(exception is a default $HOME mount, which is applied before loop device mounts).
+Note that this has been fixed in apptainer and you can now apply image mounts over bind mounts. 
 
 
 ## Convoluted path modifications in py scripts

--- a/configs/lumi.yaml
+++ b/configs/lumi.yaml
@@ -9,7 +9,7 @@ defaults:
     installation_path: "/LUMI_CONTAINER"
     # if this is not a thing which exist
     # I will do a singularity pull
-    container_src: 'docker://opensuse/leap:15.2'
+    container_src: 'docker://opensuse/leap:15.3'
     # name of the container image when on disk
     container_image: container.sif 
     sqfs_image: img.sqfs 

--- a/configs/lumi.yaml
+++ b/configs/lumi.yaml
@@ -6,7 +6,10 @@ defaults:
     env_name: env1 
     conda_version: latest
     installation_prefix: $PWD
-    installation_path: "/LUMI_CONTAINER"
+    installation_path: "/LUMI_TYKKY"
+    # Adds a random hash to the end of the path so
+    # That multiple installations can be active at the same time
+    composable: true
     # if this is not a thing which exist
     # I will do a singularity pull
     container_src: 'docker://opensuse/leap:15.3'

--- a/configs/mahti.yaml
+++ b/configs/mahti.yaml
@@ -6,7 +6,10 @@ defaults:
     env_name: env1 
     conda_version: latest
     installation_prefix: $PWD
-    installation_path: "/CSC_CONTAINER"
+    installation_path: "/MAHTI_TYKKY"
+    # Adds a random hash to the end of the path so
+    # That multiple installations can be active at the same time
+    composable: true
     # if this is not a thing which exist
     # I will do a singularity pull
     container_src: 'docker://redhat/ubi8:8.6' 

--- a/configs/puhti.yaml
+++ b/configs/puhti.yaml
@@ -5,7 +5,10 @@ defaults:
     env_name: env1 
     conda_version: latest
     installation_prefix: $PWD
-    installation_path: "/CSC_CONTAINER"
+    installation_path: "/PUHTI_TYKKY"
+    # Adds a random hash to the end of the path so
+    # That multiple installations can be active at the same time
+    composable: true
     # if this is not a thing which exist
     # I will do a singularity pull
     container_src: 'docker://redhat/ubi8:8.6' 

--- a/construct.py
+++ b/construct.py
@@ -48,6 +48,9 @@ for k,v in shared_conf["appends"].items():
         full_conf[k] = v
 full_conf.update(shared_conf["force"])
 
+if full_conf["composable"]:
+    full_conf["installation_path"]=full_conf["installation_path"]+"_"+name_generator(7)
+
 if os.getenv("CW_LOG_LEVEL"):
     full_conf["log_level"]=os.getenv("CW_LOG_LEVEL")
 

--- a/construct.py
+++ b/construct.py
@@ -48,8 +48,11 @@ for k,v in shared_conf["appends"].items():
         full_conf[k] = v
 full_conf.update(shared_conf["force"])
 
-if full_conf["composable"] and "update_installation" in full_conf  and full_conf["update_installation"] == "no":
+if (full_conf["composable"] and ("update_installation" in full_conf  and full_conf["update_installation"] == "no") and "mask_wrap_install" not in full_conf ):
     full_conf["installation_path"]=full_conf["installation_path"]+"_"+name_generator(7,string.ascii_letters + string.digits)
+
+if "wrapper_paths" in full_conf:
+    full_conf["wrapper_paths"] = [o if o[0]=="/" else full_conf["installation_path"] + "/" + o for o in full_conf["wrapper_paths"] ]
 
 if os.getenv("CW_LOG_LEVEL"):
     full_conf["log_level"]=os.getenv("CW_LOG_LEVEL")

--- a/construct.py
+++ b/construct.py
@@ -49,7 +49,7 @@ for k,v in shared_conf["appends"].items():
 full_conf.update(shared_conf["force"])
 
 if full_conf["composable"]:
-    full_conf["installation_path"]=full_conf["installation_path"]+"_"+name_generator(7)
+    full_conf["installation_path"]=full_conf["installation_path"]+"_"+name_generator(7,string.ascii_letters + string.digits)
 
 if os.getenv("CW_LOG_LEVEL"):
     full_conf["log_level"]=os.getenv("CW_LOG_LEVEL")

--- a/construct.py
+++ b/construct.py
@@ -48,7 +48,7 @@ for k,v in shared_conf["appends"].items():
         full_conf[k] = v
 full_conf.update(shared_conf["force"])
 
-if full_conf["composable"]:
+if full_conf["composable"] and "update_installation" in full_conf  and full_conf["update_installation"] == "no":
     full_conf["installation_path"]=full_conf["installation_path"]+"_"+name_generator(7,string.ascii_letters + string.digits)
 
 if os.getenv("CW_LOG_LEVEL"):

--- a/cw_common.py
+++ b/cw_common.py
@@ -51,7 +51,8 @@ def expand_vars(path,rec=0):
         return expand_vars(g.replace(f"${var}",''),rec+1)
     return g
 
-
+def has_apptainer():
+    return shutil.which("apptainer") != ""
 
 def name_generator(size=6, chars=string.ascii_uppercase + string.digits):
    return ''.join(random.choice(chars) for _ in range(size))

--- a/cw_common.py
+++ b/cw_common.py
@@ -57,7 +57,6 @@ def has_apptainer():
 def name_generator(size=6, chars=string.ascii_uppercase + string.digits):
    return ''.join(random.choice(chars) for _ in range(size))
 
-
 def installation_in_PATH():
     return [P for P in os.environ["PATH"].split(':') if is_installation(P) ]
 

--- a/cw_common.py
+++ b/cw_common.py
@@ -4,6 +4,8 @@ import os
 import random
 import string
 import pathlib
+import sys
+import shutil
 
 colors={}
 colors["RED"]='\033[0;31m'

--- a/frontends/script_shared.py
+++ b/frontends/script_shared.py
@@ -69,7 +69,7 @@ def parse_wrapper(conf,g_conf,a,req_abs):
                 print_err("Only absolute paths are accepted for --wrapper-paths/-w")
                 sys.exit(1)
             else:
-                conf["wrapper_paths"].append(ip+"/"+p)
+                conf["wrapper_paths"].append(p)
 
 def get_old_conf(d,conf):
     old_conf={}

--- a/frontends/wrap-install.py
+++ b/frontends/wrap-install.py
@@ -38,7 +38,8 @@ conf["update_installation"]="no"
 conf["template_script"]="wrap.sh"
 if args.mask:
     conf["installation_path"]=str(pathlib.Path(args.dir).resolve())
-    conf["excluded_mount_points"]="/"+conf["installation_path"].split('/')[1]
+    if not has_apptainer():
+        conf["excluded_mount_points"]="/"+conf["installation_path"].split('/')[1]
 
 if args.prefix:
     conf["installation_prefix"]=args.prefix

--- a/frontends/wrap-install.py
+++ b/frontends/wrap-install.py
@@ -40,6 +40,7 @@ if args.mask:
     conf["installation_path"]=str(pathlib.Path(args.dir).resolve())
     if not has_apptainer():
         conf["excluded_mount_points"]="/"+conf["installation_path"].split('/')[1]
+    conf["mask_wrap_install"] = True
 
 if args.prefix:
     conf["installation_prefix"]=args.prefix

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -222,6 +222,7 @@ for wrapper_path in "${CW_WRAPPER_PATHS[@]}";do
             export PATH=\"\$OLD_PATH\"
             $_RUN_CMD  $_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
         fi" >> _deploy/bin/$target
+        fi
         chmod +x _deploy/bin/$target
         if [[ "$target" == "python"  ]];then
             print_info "Found python, checking if venv" 2

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -203,25 +203,25 @@ for wrapper_path in "${CW_WRAPPER_PATHS[@]}";do
         echo "$_PRE_COMMAND" >> _deploy/bin/$target
         ln -s $wrapper_path/$target _deploy/_bin/$target
         echo "
-        if [[ \${_CW_IN_CONTAINER+defined} ]];then
-            exec -a \$_O_SOURCE \$DIR/../_bin/$target \"\$@\"
-        else" >> _deploy/bin/$target
+if [[ \${_CW_IN_CONTAINER+defined} ]];then
+    exec -a \$_O_SOURCE \$DIR/../_bin/$target \"\$@\"
+else" >> _deploy/bin/$target
         if [[ ${CONDA_CMD+defined} ]];then
         echo "
-            if [[ -e \$(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg && ! \${CW_FORCE_CONDA_ACTIVATE+defined} ]];then
-                export PATH=\"\$OLD_PATH\"
-                $_RUN_CMD $_default_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
-            else
-                export PATH=\"\$OLD_PATH\"
-                $_RUN_CMD  $_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
-            fi
-        fi
+    if [[ -e \$(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg && ! \${CW_FORCE_CONDA_ACTIVATE+defined} ]];then
+        export PATH=\"\$OLD_PATH\"
+        $_RUN_CMD $_default_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
+    else
+        export PATH=\"\$OLD_PATH\"
+        $_RUN_CMD  $_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
+    fi
+fi
         " >>  _deploy/bin/$target
         else 
-        echo"
-            export PATH=\"\$OLD_PATH\"
-            $_RUN_CMD  $_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
-        fi" >> _deploy/bin/$target
+        echo "
+    export PATH=\"\$OLD_PATH\"
+    $_RUN_CMD  $_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
+fi" >> _deploy/bin/$target
         fi
         chmod +x _deploy/bin/$target
         if [[ "$target" == "python"  ]];then

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -201,7 +201,7 @@ for wrapper_path in "${CW_WRAPPER_PATHS[@]}";do
         if [[ \${_CW_IN_CONTAINER+defined} ]];then
             exec -a \$_O_SOURCE \$DIR/../_bin/$target \"\$@\"
         else
-            if [[ -e $(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg && ! ${CW_FORCE_CONDA_ACTIVATE+defined} ]];then
+            if [[ -e \$(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg && ! \${CW_FORCE_CONDA_ACTIVATE+defined} ]];then
                 export PATH=\"\$OLD_PATH\"
                 $_RUN_CMD exec -a \$_O_SOURCE \$DIR/$target $_cwe  
             else

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -199,10 +199,15 @@ for wrapper_path in "${CW_WRAPPER_PATHS[@]}";do
         ln -s $wrapper_path/$target _deploy/_bin/$target
         echo "
         if [[ \${_CW_IN_CONTAINER+defined} ]];then
-            exec -a \$_O_SOURCE \$DIR/$target \"\$@\"
+            exec -a \$_O_SOURCE \$DIR/../_bin/$target \"\$@\"
         else
-            export PATH=\"\$OLD_PATH\"
-            $_RUN_CMD  $_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
+            if [[ -e $(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg ]];then
+                export PATH=\"\$OLD_PATH\"
+                $_RUN_CMD exec -a \$_O_SOURCE \$DIR/$target $_cwe  
+            else
+                export PATH=\"\$OLD_PATH\"
+                $_RUN_CMD  $_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
+            fi
         fi" >> _deploy/bin/$target
         chmod +x _deploy/bin/$target
         if [[ "$target" == "python"  ]];then

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -201,7 +201,7 @@ for wrapper_path in "${CW_WRAPPER_PATHS[@]}";do
         if [[ \${_CW_IN_CONTAINER+defined} ]];then
             exec -a \$_O_SOURCE \$DIR/../_bin/$target \"\$@\"
         else
-            if [[ -e $(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg ]];then
+            if [[ -e $(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg && ! ${_CV_FORCE_CONDA_ACTIVATE+defined} ]];then
                 export PATH=\"\$OLD_PATH\"
                 $_RUN_CMD exec -a \$_O_SOURCE \$DIR/$target $_cwe  
             else

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -77,10 +77,15 @@ fi
 echo "
 if  grep -q 'singularity/mnt/session\|apptainer/mnt/session' /proc/self/mountinfo ;then
     export _CW_IN_CONTAINER=Yes
-    if [[ \"\$_CW_IS_ISOLATED\" == \"yes\" || \"$CW_ISOLATE\" == \"yes\" || ! -z \${CW_NO_COMPOSE+defined} ]];then
+    if [[ \"$CW_ISOLATE\" == \"yes\" && ! \"\$( stat -c '%i' \$SINGULARITY_CONTAINER)\" == \"\$( stat -c '%i' \$_C_DIR/\$CONTAINER_IMAGE)\" ]]; then
         echo \"[ ERROR ] wrapper called from another container. Is \$SINGULARITY_CONTAINER, should be \$_C_DIR/\$CONTAINER_IMAGE \"
         exit 1 
     fi
+    if [[ ! -e $CW_INSTALLATION_PATH ]]; then
+        echo \"[ ERROR ] Installation for \$_C_DIR/ is not mounted. Wrapper called from another container?\" 
+        exit 1
+    fi
+    
 else
     unset _CW_IN_CONTAINER
     export _CW_IS_ISOLATED=$CW_ISOLATE

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -203,7 +203,7 @@ for wrapper_path in "${CW_WRAPPER_PATHS[@]}";do
         else
             if [[ -e \$(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg && ! \${CW_FORCE_CONDA_ACTIVATE+defined} ]];then
                 export PATH=\"\$OLD_PATH\"
-                $_RUN_CMD exec -a \$_O_SOURCE \$DIR/$target $_cwe  
+                $_RUN_CMD $_default_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
             else
                 export PATH=\"\$OLD_PATH\"
                 $_RUN_CMD  $_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -21,8 +21,8 @@ if [[ "$CW_MODE" == "wrapcont" ]];then
 else
     _CONTAINER_EXEC="/usr/bin/singularity --silent exec -B _deploy/$CW_SQFS_IMAGE:$CW_INSTALLATION_PATH:image-src=/ _deploy/$CW_CONTAINER_IMAGE"
     echo "SQFS_IMAGE=$CW_SQFS_IMAGE" >> _deploy/common.sh
-    _RUN_CMD="/usr/bin/singularity --silent exec -B \$DIR/../\$SQFS_IMAGE:\$INSTALLATION_PATH:image-src=/ \$DIR/../\$CONTAINER_IMAGE"
-    _SHELL_CMD="/usr/bin/singularity --silent shell -B \$DIR/../\$SQFS_IMAGE:\$INSTALLATION_PATH:image-src=/ \$DIR/../\$CONTAINER_IMAGE"
+    _RUN_CMD="/usr/bin/singularity --silent exec  \$DIR/../\$CONTAINER_IMAGE"
+    _SHELL_CMD="/usr/bin/singularity --silent shell \$DIR/../\$CONTAINER_IMAGE"
 fi
 
 # Need to unset the path, otherwise we might be stuck in a nasty loop
@@ -115,7 +115,7 @@ if [[ \"\${TMPDIR+defined}\" ]];then
     SINGULARITY_BIND=\"\$SINGULARITY_BIND,\$TMPDIR,\$TMPDIR:/tmp\"
 fi
 SINGULARITY_BIND=\"\$SINGULARITY_BIND,\$( /usr/bin/readlink -f \$_C_DIR/_bin):\$( /usr/bin/readlink -f \$_C_DIR/bin)\"
-export SINGULARITY_BIND" >> _deploy/common.sh
+export SINGULARITY_BIND=\$SINGULARITY_BIND:\$DIR/../\$SQFS_IMAGE:\$INSTALLATION_PATH:image-src=/" >> _deploy/common.sh
 
 # The above readlink is only needed as a workaround for Lumi
 # where some folders are symlinked to lustre mount points

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -114,9 +114,12 @@ done
 if [[ \"\${TMPDIR+defined}\" ]];then
     SINGULARITY_BIND=\"\$SINGULARITY_BIND,\$TMPDIR,\$TMPDIR:/tmp\"
 fi
-SINGULARITY_BIND=\"\$SINGULARITY_BIND,\$( /usr/bin/readlink -f \$_C_DIR/_bin):\$( /usr/bin/readlink -f \$_C_DIR/bin)\"
-export SINGULARITY_BIND=\$SINGULARITY_BIND,\$DIR/../\$SQFS_IMAGE:\$INSTALLATION_PATH:image-src=/" >> _deploy/common.sh
-
+SINGULARITY_BIND=\"\$SINGULARITY_BIND,\$( /usr/bin/readlink -f \$_C_DIR/_bin):\$( /usr/bin/readlink -f \$_C_DIR/bin)\"" >> _deploy/common.sh
+if [[ "$CW_MODE" == "wrapcont" ]];then
+    echo "export SINGULARITY_BIND" >> _deploy/common.sh
+else
+    echo "export SINGULARITY_BIND=\$SINGULARITY_BIND,\$DIR/../\$SQFS_IMAGE:\$INSTALLATION_PATH:image-src=/" >> _deploy/common.sh
+fi
 # The above readlink is only needed as a workaround for Lumi
 # where some folders are symlinked to lustre mount points
 

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -78,8 +78,8 @@ fi
 echo "
 if  grep -q 'singularity/mnt/session\|apptainer/mnt/session' /proc/self/mountinfo ;then
     export _CW_IN_CONTAINER=Yes
-    if [[ ! \"\$SINGULARITY_CONTAINER\" == \"\$_C_DIR/\$CONTAINER_IMAGE\"  ]];then
-        echo \"[ ERROR ] wrapper called from another container. Is \$SINGULARITY_CONTAINER, should be \$_C_DIR/\$CONTAINER_IMAGE \" 
+    if [[ ! \"\$( stat -c '%i' \$SINGULARITY_CONTAINER)\" == \"\$( stat -c '%i' \$_C_DIR/\$CONTAINER_IMAGE)\"  ]];then
+        echo \"[ ERROR ] wrapper called from another container. Is \$SINGULARITY_CONTAINER, should be \$_C_DIR/\$CONTAINER_IMAGE \"
         exit 1
     fi
 else

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -203,6 +203,7 @@ for wrapper_path in "${CW_WRAPPER_PATHS[@]}";do
         ln -s $wrapper_path/$target _deploy/_bin/$target
         echo "
 if [[ \${_CW_IN_CONTAINER+defined} ]];then
+    export PATH=\"\$OLD_PATH\"
     exec -a \$_O_SOURCE \$DIR/../_bin/$target \"\$@\"
 else" >> _deploy/bin/$target
         if [[ ${CONDA_CMD+defined} ]];then

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -44,7 +44,6 @@ _PRE_COMMAND="source \$DIR/../common.sh"
 echo "_C_DIR=\"\$( cd \"\$( dirname \"\${BASH_SOURCE[0]}\" )\" >/dev/null 2>&1 && pwd )\"
 CONTAINER_IMAGE=$CW_CONTAINER_IMAGE
 INSTALLATION_PATH=$CW_INSTALLATION_PATH
-export SINGULARITYENV_PATH=\"\$_C_DIR/bin:\$SINGULARITYENV_PATH\"
 ">> _deploy/common.sh
 if [[ ${CW_WRAPPER_LD_LIBRARY_PATHS+defined} ]]; then
     echo "export SINGULARITYENV_LD_LIBRARY_PATH=\"\$SINGULARITYENV_LD_LIBRARY_PATH:$(echo "${CW_WRAPPER_LD_LIBRARY_PATHS[@]}" | tr ' ' ':' )\"">> _deploy/common.sh
@@ -62,7 +61,7 @@ export SINGULARITYENV_LD_LIBRARY_PATH=\"\$SINGULARITYENV_LD_LIBRARY_PATH:\$SINGU
 
 else
     echo "_DIRS=(\$(/usr/bin/ls -1 / | /usr/bin/awk '!/dev/' | /usr/bin/sed 's/^/\//g' ))" >> _deploy/common.sh
-    echo "export SINGULARITYENV_PATH=\"\$SINGULARITYENV_PATH:\$OLD_PATH\"
+    echo "export SINGULARITYENV_PATH=\"\$OLD_PATH\"
 export SINGULARITYENV_LD_LIBRARY_PATH=\"\$SINGULARITYENV_LD_LIBRARY_PATH:\$LD_LIBRARY_PATH\"" >> _deploy/common.sh
 
 if [[ "${CW_EXCLUDED_MOUNT_POINTS+defined}" ]];then

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -115,7 +115,7 @@ if [[ \"\${TMPDIR+defined}\" ]];then
     SINGULARITY_BIND=\"\$SINGULARITY_BIND,\$TMPDIR,\$TMPDIR:/tmp\"
 fi
 SINGULARITY_BIND=\"\$SINGULARITY_BIND,\$( /usr/bin/readlink -f \$_C_DIR/_bin):\$( /usr/bin/readlink -f \$_C_DIR/bin)\"
-export SINGULARITY_BIND=\$SINGULARITY_BIND:\$DIR/../\$SQFS_IMAGE:\$INSTALLATION_PATH:image-src=/" >> _deploy/common.sh
+export SINGULARITY_BIND=\$SINGULARITY_BIND,\$DIR/../\$SQFS_IMAGE:\$INSTALLATION_PATH:image-src=/" >> _deploy/common.sh
 
 # The above readlink is only needed as a workaround for Lumi
 # where some folders are symlinked to lustre mount points

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -77,7 +77,7 @@ fi
 echo "
 if  grep -q 'singularity/mnt/session\|apptainer/mnt/session' /proc/self/mountinfo ;then
     export _CW_IN_CONTAINER=Yes
-    if [[ \"\$_CW_IS_ISOLATED\" == \"yes\" || \"\$CW_ISOLATE\" == \"\$yes\" || ! -z \${CW_NO_COMPOSE+defined} ]];then
+    if [[ \"\$_CW_IS_ISOLATED\" == \"yes\" || \"$CW_ISOLATE\" == \"yes\" || ! -z \${CW_NO_COMPOSE+defined} ]];then
         echo \"[ ERROR ] wrapper called from another container. Is \$SINGULARITY_CONTAINER, should be \$_C_DIR/\$CONTAINER_IMAGE \"
         exit 1 
     fi

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -126,8 +126,8 @@ if [[ "$CW_MODE" == "wrapcont" ]];then
 else
     echo "export SINGULARITY_BIND=\$SINGULARITY_BIND,\$DIR/../\$SQFS_IMAGE:\$INSTALLATION_PATH:image-src=/" >> _deploy/common.sh
 fi
-echo "if [[ \${CW_EXTRA_BIND_MOUNTS+defined} ]]; then
-    export SINGULARITY_BIND=\$SINGULARITY_BIND:\$(echo \$CW_EXTRA_BIND_MOUNTS |  sed \"s@\$_C_DIR/\$SQFS_IMAGE:\$INSTALLATION_PATH:image-src=/@@g\")
+echo "if [[ \${CW_EXTRA_BIND_MOUNTS+defined} && \"$CW_ISOLATE\" == \"no\" ]]; then
+    export SINGULARITY_BIND=\$SINGULARITY_BIND,\$(echo \$CW_EXTRA_BIND_MOUNTS |  sed \"s@\$_C_DIR/\$SQFS_IMAGE:\$INSTALLATION_PATH:image-src=/@@g\")
 fi" >> _deploy/common.sh
 
 

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -201,7 +201,7 @@ for wrapper_path in "${CW_WRAPPER_PATHS[@]}";do
         if [[ \${_CW_IN_CONTAINER+defined} ]];then
             exec -a \$_O_SOURCE \$DIR/../_bin/$target \"\$@\"
         else
-            if [[ -e $(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg && ! ${_CV_FORCE_CONDA_ACTIVATE+defined} ]];then
+            if [[ -e $(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg && ! ${CW_FORCE_CONDA_ACTIVATE+defined} ]];then
                 export PATH=\"\$OLD_PATH\"
                 $_RUN_CMD exec -a \$_O_SOURCE \$DIR/$target $_cwe  
             else

--- a/post.sh
+++ b/post.sh
@@ -18,6 +18,10 @@ fi
             mv $CW_BUILD_TMPDIR/_inst_dir/$( basename $_fil ) $CW_INSTALLATION_PREFIX/share 
         done
     fi
+    echo "tag: $(git -C $SCRIPT_DIR describe --tags)" >> $CW_INSTALLATION_PREFIX/share/VERSION.yml
+    echo "commit: $(git -C $SCRIPT_DIR rev-parse --short HEAD )" >>  $CW_INSTALLATION_PREFIX/share/VERSION.yml
+    echo "build-time: $(date)" >>  $CW_INSTALLATION_PREFIX/share/VERSION.yml 
+    
     cp $CW_BUILD_TMPDIR/conf.yaml $CW_INSTALLATION_PREFIX/share
 
 rm -rf $CW_BUILD_TMPDIR

--- a/post.sh
+++ b/post.sh
@@ -7,9 +7,13 @@ source $CW_BUILD_TMPDIR/_vars.sh
 print_info "Installing to $CW_INSTALLATION_PREFIX" 1
 
 if [[ ${CW_UPDATE_INSTALLATION+defined } && "$CW_UPDATE_INSTALLATION" == "yes" ]];then
-    rm -fr $CW_INSTALLATION_PREFIX/bin
-    rm -fr $CW_INSTALLATION_PREFIX/_bin
-    rm -fr $CW_INSTALLATION_PREFIX/share
+    # This might fail if the installation resides on a lustre file system
+    # And is being used by another client while we try to remove the bin directory
+    # Due to the bin being using in a filesystem mount
+    # This would produce the error "rm: 'cannot remove Path/to/bin': Device or resource busy"
+    rm -fr $CW_INSTALLATION_PREFIX/bin || print_warn "Failed to remove $CW_INSTALLATION_PREFIX/bin due to it being in use\n\tContinuing anyway"
+    rm -fr $CW_INSTALLATION_PREFIX/_bin 
+    rm -fr $CW_INSTALLATION_PREFIX/share  
 fi
     cp -rd $CW_BUILD_TMPDIR/_deploy/* $CW_INSTALLATION_PREFIX/
     mkdir -p $CW_INSTALLATION_PREFIX/share

--- a/post.sh
+++ b/post.sh
@@ -22,7 +22,7 @@ fi
             mv $CW_BUILD_TMPDIR/_inst_dir/$( basename $_fil ) $CW_INSTALLATION_PREFIX/share 
         done
     fi
-    echo "tag: $(git -C $SCRIPT_DIR describe --tags)" >> $CW_INSTALLATION_PREFIX/share/VERSION.yml
+    echo "tag: $(git -C $SCRIPT_DIR describe --tags)" > $CW_INSTALLATION_PREFIX/share/VERSION.yml
     echo "commit: $(git -C $SCRIPT_DIR rev-parse --short HEAD )" >>  $CW_INSTALLATION_PREFIX/share/VERSION.yml
     echo "build-time: $(date)" >>  $CW_INSTALLATION_PREFIX/share/VERSION.yml 
     

--- a/templates/venv.sh
+++ b/templates/venv.sh
@@ -13,9 +13,7 @@ cd $CW_INSTALLATION_PATH
 cd $CW_WORKDIR
 source $CW_INSTALLATION_PATH/_pre_install.sh
 cd $CW_INSTALLATION_PATH
-python3 -m venv $CW_ENV_NAME
-print_info "Installing requirements file" 1
-source $CW_INSTALLATION_PATH/$CW_ENV_NAME/bin/activate
+
 if [[ ${CW_ENABLE_SITE_PACKAGES+defined} ]];then
     print_info "Enabling system and user site packages" 1
     _SP="--system-site-packages"
@@ -23,9 +21,12 @@ else
     print_info "Not enabling system and user site packages" 1
     _SP=""
 fi
+print_info "Installing requirements file" 1
+python3 -m venv $_SP $CW_ENV_NAME
+source $CW_INSTALLATION_PATH/$CW_ENV_NAME/bin/activate
 
 if [[ ${CW_REQUIREMENTS_FILE+defined}  ]];then
-    pip install $_SP --disable-pip-version-check -r "$( basename $CW_REQUIREMENTS_FILE)"  
+    pip install --disable-pip-version-check -r "$( basename $CW_REQUIREMENTS_FILE)"  
 fi
 cd $CW_WORKDIR
 print_info "Running user supplied commands" 1

--- a/tests/more_tests.sh
+++ b/tests/more_tests.sh
@@ -22,7 +22,7 @@ fi
 export CW_GLOBAL_YAML=$( readlink -f my_config.yaml)
 mkdir PIP_INSTALL_DIR
 t_run "pip-containerize new --prefix PIP_INSTALL_DIR req.txt" "Basic pip installation ok"
-t_run "PIP_INSTALL_DIR/bin/python -c 'import site;import sys;sys.exit(site.ENABLE_USER_SITE == False )'" "Site packages disabled by default"
+t_run "PIP_INSTALL_DIR/bin/python -c 'import site;import sys;sys.exit(site.ENABLE_USER_SITE  )'" "Site packages disabled by default"
 t_run "PIP_INSTALL_DIR/bin/python -c 'import yaml'" "Required package is present"
 t_run "[[ -L PIP_INSTALL_DIR/container.sif  ]]" "Container is symlink"
 c1=$(readlink -f test_container.sif )

--- a/tests/more_tests.sh
+++ b/tests/more_tests.sh
@@ -21,6 +21,8 @@ else
 fi
 export CW_GLOBAL_YAML=$( readlink -f my_config.yaml)
 mkdir PIP_INSTALL_DIR
+t_run "pip-containerize new --system-site-packages --prefix PIP_INSTALL_DIR req.txt" "System site packages flag"
+t_run "PIP_INSTALL_DIR/bin/python -c 'import site;import sys;sys.exit(not site.ENABLE_USER_SITE  )'" "Site packages can be enabled"
 t_run "pip-containerize new --prefix PIP_INSTALL_DIR req.txt" "Basic pip installation ok"
 t_run "PIP_INSTALL_DIR/bin/python -c 'import site;import sys;sys.exit(site.ENABLE_USER_SITE  )'" "Site packages disabled by default"
 t_run "PIP_INSTALL_DIR/bin/python -c 'import yaml'" "Required package is present"

--- a/tests/test-03.sh
+++ b/tests/test-03.sh
@@ -1,0 +1,84 @@
+#!/bin/bash -eu
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/setup.sh
+# Test are run in current directory
+
+#rm -fr T_TEST_DIR
+#mkdir T_TEST_DIR
+cd T_TEST_DIR
+#mkdir Gdal
+#mkdir S
+#echo 'channels:
+#  - conda-forge
+#  - bioconda
+#dependencies:
+#  - python>=3.10
+#  - snakemake
+#' > env2.yml
+#echo '
+#channels:
+#  - conda-forge
+#dependencies:
+#  - python>=3.10
+#  - gdal
+#' > env.yml
+#echo 'rule all:
+#	input: "out.txt"
+#rule ghelp:
+#    output: "out.txt"
+#    shell:
+#        """
+#        gdaladdo --help-general | grep -q "Generic GDAL utility command options" > out.txt
+#        """
+#' > Snakefile
+#
+#t_run "conda-containerize new --mamba env2.yml --prefix S" "mamba works" 
+#t_run "conda-containerize new --mamba env.yml --prefix Gdal" "gdal installed"
+export OPATH=$PATH
+export PATH=$PWD/Gdal/bin:$PATH
+export PATH=$PWD/S/bin:$PATH
+export CW_EXTRA_BIND_MOUNTS=$PWD/Gdal/img.sqfs:$(Gdal/bin/_debug_exec bash -c "echo \$install_root"):image-src=/
+t_run "gdaladdo --help-general | grep -q 'Generic GDAL utility command options'" "Filter out own bind mount"
+t_run "snakemake -j1" "Composition works"
+t_run "Gdal/bin/_debug_exec Gdal/_bin/gdaladdo --help-general | grep -q 'Generic GDAL utility command options'" "_bin directory works"
+rm out.txt
+export CW_EXTRA_BIND_MOUNTS=$CW_EXTRA_BIND_MOUNTS:$PWD/S/img.sqfs:$(S/bin/_debug_exec bash -c "echo \$install_root"):image-src=/
+t_run 'Gdal/bin/_debug_exec snakemake --help |  grep "usage: snakemake" -q' "Composition works other way around"
+t_run 'Gdal/bin/python -c "import sys;import os;sys.exit(\"CONDA_PREFIX\" not in os.environ)"' "Conda is active"
+export CW_NO_CONDA_ACTIVATE=1
+t_run 'Gdal/bin/python -c "import sys;import os;sys.exit(\"CONDA_PREFIX\" in os.environ)"' "Conda is not active"
+unset CW_NO_CONDA_ACTIVATE
+Gdal/bin/python -m venv Py
+t_run 'Py/bin/python -c "import sys;import os;sys.exit(\"CONDA_PREFIX\" in os.environ)"' "Conda is not active in venv"
+export CW_FORCE_CONDA_ACTIVATE=1
+t_run 'Py/bin/python -c "import sys;import os;sys.exit(\"CONDA_PREFIX\" not in os.environ)"' "Conda can be activated in venv"
+unset CW_FORCE_CONDA_ACTIVATE
+unset CW_EXTRA_BIND_MOUNTS
+mkdir -p M MyProg/bin N
+echo 'echo HELLO' > MyProg/bin/PP
+chmod +x MyProg/bin/PP
+export PATH=$OPATH
+t_run "wrap-install MyProg/ -w bin --mask --prefix M" "Wrap install --mask"
+t_run "M/bin/PP | grep -q HELLO" "wrap-install with --mask works"
+t_run "M/bin/_debug_exec touch MyProg/A 2>&1 | grep -q 'Read-only file system'" "--mask covers disk" 
+t_run "wrap-install MyProg/ -w bin --prefix N" "Wrap install nomask"
+t_run "N/bin/PP | grep -q HELLO" "wrap-install without --mask works"
+t_run "N/bin/_debug_exec touch MyProg/A" "disk installation is not masked"
+export CW_EXTRA_BIND_MOUNTS=$PWD/MyProg/img.sqfs:$PWD/MyProg:image-src=/:$PWD/S/img.sqfs:$(S/bin/_debug_exec bash -c "echo \$install_root"):image-src=/:$PWD/Gdal/img.sqfs:$(Gdal/bin/_debug_exec bash -c "echo \$install_root"):image-src=/
+rm -rf MyProg
+mv M MyProg
+t_run "S/bin/_debug_exec MyProg/bin/PP | grep -q HELLO" "Composition works into wrapped"
+t_run 'MyProg/bin/_debug_exec S/bin/snakemake --help |  grep "usage: snakemake" -q' "Composition works from wrapped"
+export PATH=$PWD/Gdal/bin:$PATH
+t_run "MyProg/bin/_debug_exec gdaladdo --help-general | grep -q 'Generic GDAL utility command options'" "Multi composition works"
+t_run 'MyProg/bin/_debug_exec S/bin/snakemake -j 1' "Nested composition works"
+t_run 'MyProg/bin/_debug_exec bash -c "echo \$SINGULARITY_BIND" | grep -q "/$(echo $PWD | cut -d "/" -f2),"' "Top mount point is not excluded"
+mkdir 2.1.0
+t_run 'wrap-container -w /whitebox_tools docker://crazyzlj/whitebox-tools:2.1.0 --prefix 2.1.0' "Wrap container from external source" 
+t_run "2.1.0/bin/whitebox_tools --help" "Using sh if bash not available for wrap container"
+t_run 'Gdal/bin/_debug_exec 2.1.0/bin/whitebox_tools --help  | grep  "wrapper called from another container" -q' "Wrapped container gives error when cross called"
+res=$(2.1.0/bin/_debug_exec sh -c "echo \$SINGULARITY_BIND" | grep -q -- "image-src")
+t_run "test -z $res" "No extra bind mounts into wrapped container"
+t_run "grep -q $(git describe --tags) 2.1.0/share/VERSION.yml" "Version information saved"
+
+


### PR DESCRIPTION
- Don't activate conda when called through a venv
        Override with CW_FORCE_CONDA_ACTIVATE
- Handle nested invocation when there are top level symlinks
- Document enabling user conda rc
        CW_ENABLE_CONDARC
- Don't exclude mount points for wrap install if using apptainer
- Save extra version information to share
- Fix bug which stopped updates when the installation was in use on the same node. 
- New feature: composable installations  