### PR TITLE
Work with older versions of git

### DIFF
--- a/post.sh
+++ b/post.sh
@@ -22,8 +22,8 @@ fi
             mv $CW_BUILD_TMPDIR/_inst_dir/$( basename $_fil ) $CW_INSTALLATION_PREFIX/share 
         done
     fi
-    echo "tag: $(git -C $SCRIPT_DIR describe --tags)" > $CW_INSTALLATION_PREFIX/share/VERSION.yml
-    echo "commit: $(git -C $SCRIPT_DIR rev-parse --short HEAD )" >>  $CW_INSTALLATION_PREFIX/share/VERSION.yml
+    echo "tag: $(cd $SCRIPT_DIR; git describe --tags)" > $CW_INSTALLATION_PREFIX/share/VERSION.yml
+    echo "commit: $(cd $SCRIPT_DIR; git rev-parse --short HEAD )" >>  $CW_INSTALLATION_PREFIX/share/VERSION.yml
     echo "build-time: $(date)" >>  $CW_INSTALLATION_PREFIX/share/VERSION.yml 
     
     cp $CW_BUILD_TMPDIR/conf.yaml $CW_INSTALLATION_PREFIX/share


### PR DESCRIPTION
Legacy versions of git don't support -C, so use a rune that works with both old and new git.