### PR TITLE
Fixes slim update and allows for version selection

### DIFF
--- a/frontends/pip-containerize.py
+++ b/frontends/pip-containerize.py
@@ -20,6 +20,7 @@ parser_upd=add_upd_pars(subparsers)
 parser_upd.add_argument("-r","--requirements-file", type=lambda x: is_valid_file(parser, x),help="requirements file for pip")
 add_adv_pars(subparsers)
 parser_new.add_argument("--slim",action='store_true',help="Use minimal base python container")
+parser_new.add_argument("--pyver",help="Docker tag to use for the slim python verison, e.g 3.12.9-bookworm")
 parser_new.add_argument("--system-site-packages",action='store_true',help="Enable system and user site packages for the created installation")
 
 ps=[parser_new,parser_upd]
@@ -34,7 +35,7 @@ if len(sys.argv) < 2:
     sys.exit(0)
 args = parser.parse_args()
 conf={}
-pyver="3.10.0-slim-buster"
+pyver="3.12.9-slim-bookworm"
 
 
 
@@ -49,8 +50,14 @@ if args.command == "new":
         conf["installation_prefix"]=args.prefix
     conf["mode"]="venv"
     if args.slim:
+        if args.pyver:
+            pyver=args.pyver
         conf["container_src"]="docker://python:{}".format(pyver)
         conf["isolate"]="yes"
+    else:
+        if args.pyver:
+            print_warn("Using --pyver without --slim does not have an effect")
+
 elif args.command == "update":
     conf["mode"]="venv_modify"
     get_old_conf(args.dir,conf)

--- a/frontends/script_shared.py
+++ b/frontends/script_shared.py
@@ -92,5 +92,6 @@ def get_old_conf(d,conf):
     conf["installation_prefix"]=d
     conf["sqfs_image"]=old_conf["sqfs_image"]
     conf["container_image"]=old_conf["container_image"]
+    conf["isolate"]=old_conf["isolate"]
     if "wrapper_paths" in old_conf:
         conf["wrapper_paths"] = old_conf["wrapper_paths"]

--- a/tests/validate_slim.sh
+++ b/tests/validate_slim.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/setup.sh
+
+rm -rf TYKKY_V_TEST
+mkdir -p TYKKY_V_TEST
+
+cd TYKKY_V_TEST
+echo "csvkit" > requirements.txt
+echo "pip install lxml" > extra.txt
+
+t_run "pip-containerize new --slim --prefix tykky_test requirements.txt" "Creating slim container works"
+t_run "singularity exec tykky_test/container.sif cat /etc/os-release  | grep 'Debian'" "Slim container is actually using debian"
+t_run "pip-containerize update --post-install extra.txt tykky_test" "Updating a slim container works"
+t_run "pip-containerize new --slim --pyver 3.13.2-slim-bullseye --prefix tykky_test2 requirements.txt | grep 'Python 3.13.2'" "--pyver flag does not break"
+t_run "tykky_test2/bin/python --version | grep 'Python 3.13.2" "Correct python version used"


### PR DESCRIPTION
Updates to installations using the  `--slim` flag were failing as during updates the host filesystem was being mounted.
Fixed this by properly propagating isolation status.

Also:
- Introduce `--pyver` flag to allow user to set what version of python should be used
- Bumped the default version of python from 3.10 to 3.12
- Added basic test for the functionality 

Bug reported in #31 