### PR TITLE
Features 

### DIFF
--- a/configs/local.yaml
+++ b/configs/local.yaml
@@ -9,7 +9,7 @@ defaults:
     installation_path: "/LOCAL_TYKKY"
     # if this is not a thing which exist
     # I will do a singularity pull
-    container_src: 'docker://rockylinux:8.9'
+    container_src: auto
     # name of the container image when on disk
     container_image: container.sif 
     sqfs_image: img.sqfs 

--- a/configs/lumi.yaml
+++ b/configs/lumi.yaml
@@ -12,7 +12,7 @@ defaults:
     composable: true
     # if this is not a thing which exist
     # I will do a singularity pull
-    container_src: 'docker://opensuse/leap:15.5'
+    container_src: auto
     # name of the container image when on disk
     container_image: container.sif 
     sqfs_image: img.sqfs 

--- a/configs/mahti.yaml
+++ b/configs/mahti.yaml
@@ -12,7 +12,7 @@ defaults:
     composable: true
     # if this is not a thing which exist
     # I will do a singularity pull
-    container_src: 'docker://redhat/ubi8:8.10' 
+    container_src: auto
     # name of the container image when on disk
     container_image: container.sif 
     sqfs_image: img.sqfs 

--- a/configs/puhti.yaml
+++ b/configs/puhti.yaml
@@ -11,7 +11,7 @@ defaults:
     composable: true
     # if this is not a thing which exist
     # I will do a singularity pull
-    container_src: 'docker://redhat/ubi8:8.6' 
+    container_src: auto 
     # name of the container image when on disk
     container_image: container.sif 
     sqfs_image: img.sqfs 

--- a/construct.py
+++ b/construct.py
@@ -57,6 +57,15 @@ if "wrapper_paths" in full_conf:
 if os.getenv("CW_LOG_LEVEL"):
     full_conf["log_level"]=os.getenv("CW_LOG_LEVEL")
 
+if full_conf["container_src"] == "auto":
+    success,container_source = get_docker_image("/etc/os-release")
+    if not success:
+        print_err("Unable to automatically determine base container to use: "+container_source,True)
+        sys.exit(1) 
+    else:
+        print_info("Automatically determined base container to: "+container_source,full_conf["log_level"],2,True)
+    full_conf["container_src"] = f"docker://{container_source}"
+
 if os.getenv("CW_BUILD_TMPDIR"):
     full_conf["build_tmpdir_base"]=os.getenv("CW_BUILD_TMPDIR")
 tmpdir_base=full_conf["build_tmpdir_base"]

--- a/frontends/containerize
+++ b/frontends/containerize
@@ -23,7 +23,7 @@ clean_up () {
     else
         test -f "$_usr_yaml" && rm "$_usr_yaml"
         test -d "$CW_BUILD_TMPDIR" && rm -r "$CW_BUILD_TMPDIR"
-        print_err "Set CW_DEBUG_KEEP_FILES env variable to keep build files"
+        print_err "Set CW_DEBUG_KEEP_FILES env variable to keep build files or set CW_LOG_LEVEL to a higher value for more output, e.g. CW_LOG_LEVEL=3"
     fi
     trap 2
     kill  -- -$$ &>/dev/null
@@ -90,8 +90,10 @@ else
    print_warn "Umask set to $CW_UMASK, check permissions of finished installation" 
 fi
 
-chgrp $(stat -c "%G" $CW_INSTALLATION_PREFIX ) $CW_BUILD_TMPDIR
-chmod g+s $CW_BUILD_TMPDIR
+_install_prefix_group=$(stat -c "%G" $CW_INSTALLATION_PREFIX )
+chgrp $_install_prefix_group $CW_BUILD_TMPDIR || print_warn "Failed to match group ownership of installation directory, attempted group was $_install_prefix_group"
+chmod g+s $CW_BUILD_TMPDIR || print_warn "Failed to set group stickybit for build directory, installation permissions might be incorrect. Please check once the installation is done."
+print_info "Setting group ownership of build directory to $_install_prefix_group" 2 
 
 if [[ "$CW_INSTALLATION_PREFIX" = /* ]]; then
    export _inst_path=$CW_INSTALLATION_PREFIX

--- a/generate_wrappers.sh
+++ b/generate_wrappers.sh
@@ -216,12 +216,17 @@ if [[ \${_CW_IN_CONTAINER+defined} ]];then
 else" >> _deploy/bin/$target
         if [[ ${CONDA_CMD+defined} ]];then
         echo "
-        if [[ ( -e \$(/usr/bin/dirname \$_O_SOURCE )/../pyvenv.cfg && ! \${CW_FORCE_CONDA_ACTIVATE+defined} ) || \${CW_NO_CONDA_ACTIVATE+defined} ]];then
+        _venvd=\$(/usr/bin/dirname \$_O_SOURCE )
+        test -e \$_venvd/../pyvenv.cfg
+        _v_in_use=\$?
+        if [[ ( \$_v_in_use -eq 0 && ! \${CW_FORCE_CONDA_ACTIVATE+defined} ) || \${CW_NO_CONDA_ACTIVATE+defined} ]];then
         export PATH=\"\$OLD_PATH\"
         $_RUN_CMD $_default_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
     else
         export PATH=\"\$OLD_PATH\"
-        $_RUN_CMD  $_cws exec -a \$_O_SOURCE \$DIR/$target $_cwe  
+        _venv_act=\":\"
+        test 0 -eq \$_v_in_use && _venv_act=\"source \$_venvd/activate\" 
+        $_RUN_CMD  $_cws \$_venv_act && exec -a \$_O_SOURCE \$DIR/$target $_cwe  
     fi
 fi
         " >>  _deploy/bin/$target


### PR DESCRIPTION
- Automatically determine host os for base container
- Warn when group setting fails, and don't stop the installation
- Activate venv when forcing conda to be active 

Logic for venv activation:

- An existing `conda-containerize` installation is used to create a venv.
- If no variables are set, the venv will be active (not by explicit activation but by the virtue of being called -> equivalent by python standard ) in the container but the conda environment will not be in `PATH`. 
- Setting `CW_FORCE_CONDA_ACTIVATE` will first activate the conda environment and then the virtual env on startup
(This was done to reduce the complexity of manually shuffling around the `PATH` entries)
- The use case where you would want for both the venv and conda to be in `PATH` but for the conda environment not to be active is not considered or supported. 




