### PR TITLE
Enable use of SUSE 15.7

### DIFF
--- a/cw_common.py
+++ b/cw_common.py
@@ -98,7 +98,7 @@ special["rhel"]= lambda namespace,version: namespace+version.split('.')[0]
 def get_docker_image(release_file):
     os_release_file = release_file
     docker_images = {
-        "sles": "opensuse/leap",
+        "sles": "registry.suse.com/bci/bci-base",
         "rhel": "redhat/ubi",
         "almalinux": "almalinux",
         "rocky": "rockylinux/rockylinux",


### PR DESCRIPTION
The new Cray OS is based on SLES 15 SP7 which would triggers downloading of OpenSuse 15.7. But that version doesn't exist as OpenSuse has moved from 15.6 to 16.0. Therefore, no OpenSuse 15.7 exists in the official docker repository.

To solve this, this MR changes the repository for downloading SLES compatible images to the official SUSE Linux Enterprise Server Base Container Image repository which provides images from SLES 15 SP 3 up the latest at time of writing SLES 16 SP 1.